### PR TITLE
Geometer: use a lower-bound threshold for "at level" operation

### DIFF
--- a/geometer/geometer.cpp
+++ b/geometer/geometer.cpp
@@ -723,7 +723,7 @@ int PLUGINCORE::processw(float const * in, float * out, int samples,
     enum { ABOVE, BETWEEN, BELOW };
 
     int state = BETWEEN;
-    float level = (pointparam * .9999f) + .00005f;
+    float const level = (pointparam * .9999f) + .00005f;
     numpts = 1;
 
     px[0] = 0;
@@ -731,14 +731,14 @@ int PLUGINCORE::processw(float const * in, float * out, int samples,
 
     for(int i = 0; i < samples; i++) {
 
-      if (in[i] > pointparam) {
+      if (in[i] > level) {
         if (state != ABOVE) {
           px[numpts] = i;
           py[numpts] = in[i];
           numpts++;
           state = ABOVE;
         }
-      } else if (in[i] < -pointparam) {
+      } else if (in[i] < -level) {
         if (state != BELOW) {
           px[numpts] = i;
           py[numpts] = in[i];


### PR DESCRIPTION
The only remaining compiler warning for me in our codebase has been this unused variable level in Geometer.  Looking at it in context, I think the intention was to provide a lower-bounds audio threshold within which the "between" state for "at level" point generation is detected?  I think without this and with the point parameter slider at its minimum, an audio sample is only "between" when it is exactly zero, and then with this scaling anything between -.00005 and .00005 (about -86 dB) will be deemed "between".

I played around both ways, and honestly I couldn't hear a difference with the audio material I was using.  But I'm not really sure what the auditory effect of the "between" state is supposed to sound like.

I'm guessing that either you played with having the .00005 threshold and then changed your mind, or wanted the .00005 threshold and then didn't actually integrate it into the logic, but I'm not sure which!  If it already is as intended, then I'll just update this PR to delete the unused variable instead.

Anyway, just very minor tidying, but thought to run it by you if you have any memory or opinions on this.