### PR TITLE
site: remove mailing list sign-up

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -371,22 +371,6 @@
     <img style="vertical-align:bottom" src="email.png" alt="The email address is at gmail.com, and is our name (destroyfx) plus the two-digit year we were founded, 99." /></p>
     
     <p>Please consider looking at our <a href="faq.html">Frequently Asked Questions</a> page first, though.</p>
-
-  </div>
-  
-  <div class="infobox" id="join">
-    <h1><img src="dfx-list.png" alt="E-mail list"></h1>
-
-    <form action="http://spacebar.org/f/a/list/add" method="post">
-      <input type="hidden" name="list" value="1">
-      <br><input type="text" name="name" maxlength="128"> &larr; your name
-      <br><input type="text" name="email" maxlength="128"> &larr; your e-mail
-      <br><input type="submit" value="Join!">
-    </form>
-    
-    <p>Join the Destroy FX mailing list to be alerted of new plugin releases. It's low traffic,
-      easy to sign up, and we'll never give your name or email address out to anyone, for any
-      reason.</p>
   </div>
 
   <div class="infobox" id="smexlinks">


### PR DESCRIPTION
This is a discussion pull request.  Should we remove the mailing list sign-up from our website?  Reasons why I think maybe yes:
* I'm not sure that it actually still works? The link to view the list shows me `uncaught exception E_DIE: required: list`.
* I don't know that I would feel confident in using it.  I think it received lots of robo/spam subscriptions.  It goes back two decades, most of which was inactivity on our end.
* There's no way to unsubscribe yourself, which I think is now required by regulations?
* I'm not sure how we would actually send a mass email of that size?  How to automate individual sends that would not go to most people's spam filters?  Or BCC mass mail that would not wind up in the spam filter?

Those are my concerns, but what do you think, and do you share any of them?

If we don't want to drop having  a mailing list altogether, do you think that any of those reasons warrant sprucing up the system?  Or using some existing free service to manage a new list?