### PR TITLE
site: restore "donate" page and links to it

### DIFF
--- a/site/donate.html
+++ b/site/donate.html
@@ -24,7 +24,6 @@
   <div class="infobox donate">
     <h1><img alt="Donations" src="dfx-donate.png" /></h1>
 
-<!--
 <p class="plea">Making plugins is fun, but there's a lot
 of work involved, and some of that work isn't fun. In fact, it feels
 like a damn job. Lots of plugin developers have noticed this too, and
@@ -32,21 +31,22 @@ some of them charge shareware fees (or worse) for the use of their
 plugins. We don't like this idea &mdash; the Destroy FX philosophy has
 always been to offer our software for free.</p>
 
-<p class="plea">However, if you really like our plugins or
-use them for work you get paid for, you might consider making a
-donation to encourage us. You can donate to Destroy FX in general, or
-you can donate for a specific plugin that you really like. Click one
-of the links on the left to make a payment via PayPal. (It's really 
-easy to do and you can use it to pay with a credit card even if you 
+<p class="plea">However, if you really like our plugins or use them
+in work for which you get paid, you might consider making a donation
+to encourage us. Click button below to make a payment via PayPal.
+(It's really easy to do and you can pay with a credit card even if you
 don't have a PayPal account.) You can give us any amount you want.</p>
 
-<p class="plea">And if you're out of cereal too, you can
+<p class="plea">And if you are not flush with cash, you can
 always <b><a href="http://msg.spacebar.org/f/a/s/msg/disp/10">Leave Us
 A Nice Message</a></b>, which is also good encouragement. (But not as
 good as <i>ca$h money!</i>)</p>
--->
 
-    <p> We are not currently accepting donations.</p>
+<form action="https://www.paypal.com/donate" method="post" target="_top" style="text-align: center">
+  <input type="hidden" name="hosted_button_id" value="9LY67GB6EFP5N" />
+  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif" border="0" name="submit" title="donate with PayPal" alt="donate with PayPal button" />
+  <img alt="" border="0" src="https://www.paypal.com/en_US/i/scr/pixel.gif" width="1" height="1" />
+</form>
 
     <p>Many thanks and much gratitude to those who have kindly shared donations with us:  
       Paul Seymour, 
@@ -211,4 +211,3 @@ good as <i>ca$h money!</i>)</p>
 </div>
 
 </body>
-

--- a/site/index.html
+++ b/site/index.html
@@ -70,8 +70,7 @@
       <b>Hello.</b>  Super Destroy FX is a collection of
       <a href="https://en.wikipedia.org/wiki/Audio_Units">Audio Units</a> and
       <a href="https://en.wikipedia.org/wiki/Virtual_Studio_Technology">VST plugins</a>
-      by Sophia and
-      <a href="http://tom7.org/">Tom 7</a>.
+      by Sophia and <a href="http://tom7.org/">Tom 7</a>.
     </p>
 
     <p>
@@ -82,8 +81,8 @@
       <li><a href="http://msg.spacebar.org/f/a/s/msg/disp/10">tell us</a> if you use them in a song
         that you release</li>
       <li>let others know where they can find this website</li>
-      <!-- <li><a href="donate.html">make a donation</a>, if you feel like these plugins are worth
-           something to you</li>-->
+      <li><a href="donate.html">make a donation</a>, if you feel like these plugins are worth
+        something to you</li>
     </ul>
 
     <p>
@@ -119,8 +118,8 @@
     <a href="source.html">source code</a>
     <br>
     <a href="#contact">contact</a> |
-    <a href="http://msg.spacebar.org/f/a/s/msg/disp/10">message board</a>
-    <!--| <a href="donate.html">donate</a>-->
+    <a href="http://msg.spacebar.org/f/a/s/msg/disp/10">message board</a> |
+    <a href="donate.html">donate</a>
     <br>
     <a href="faq.html#installation">installation instructions</a> |
     <a href="sysreq.html">system requirements</a>


### PR DESCRIPTION
Since we are working on these in earnest now, it no longer gives me discomfort having the donation link.  Particularly since I just starting paying Apple a $100 annual fee for the blessings of code-signing and notarization (increasingly required by macOS runtime hardening security measures).

The links used to have a bunch of PHP obfuscation to hide my email address, and also there were separate links to give for each plugin.  I actually wound up spinning off a "business" PayPal account which gives more options than just a link containing an email address, used their current tools to generate a "donate" button link, and with this chose to simplify and just have a single donation option rather than general + each individual plugin.  If you'd prefer any of these to be done in other ways, please ding me in review here.