### PR TITLE
site: add dividers between documentation links and remove the list item bullets

### DIFF
--- a/site/docs.html
+++ b/site/docs.html
@@ -12,6 +12,19 @@
    }
    ul.doclist {
      font-size: 18px;
+     list-style-type: none;
+     padding-left: 1em;
+     padding-right: 1em;
+   }
+   li {
+     border-top: 1px solid #ddd;
+     padding: 0.2em 0;
+   }
+   li:first-child {
+     border: 0;
+   }
+   a {
+     text-decoration: none;
    }
   </style>
 </head>


### PR DESCRIPTION
Aside from the work-in-progress museum, the only other thing on our nouveau website that I don't like as much is the documentation list.  I think the look is a bit heavy with tightly spaced large-bold-font links with bullets.  This page used to be a table with last-update dates, the latter of which I don't really think is necessary, but I played around a bit with making a little more space and using that to add some visual delineation between the links.  like / dislike / alterations?