### PR TITLE
Rez Synth + Skidder: add snoot.org font now use in GUIs into projects…

### DIFF
--- a/geometer/win32/resources.rc
+++ b/geometer/win32/resources.rc
@@ -1,4 +1,3 @@
-
 destroy-fx-link.png  PNG DISCARDABLE  "..\\gui\\graphics\\destroy-fx-link.png"
 fine-tune-down-button.png  PNG DISCARDABLE  "..\\gui\\graphics\\fine-tune-down-button.png"
 fine-tune-up-button.png  PNG DISCARDABLE  "..\\gui\\graphics\\fine-tune-up-button.png"
@@ -19,3 +18,5 @@ slider-handle-glowing.png  PNG DISCARDABLE  "..\\gui\\graphics\\slider-handle-gl
 slider-handle.png  PNG DISCARDABLE  "..\\gui\\graphics\\slider-handle.png"
 window-shape-button.png  PNG DISCARDABLE  "..\\gui\\graphics\\window-shape-button.png"
 window-size-button.png  PNG DISCARDABLE  "..\\gui\\graphics\\window-size-button.png"
+
+px10.ttf  DFX_TTF DISCARDABLE  "..\\..\\fonts\\px10.ttf"

--- a/polarizer/win32/resources.rc
+++ b/polarizer/win32/resources.rc
@@ -1,6 +1,7 @@
-
 destroy-fx-link.png  PNG DISCARDABLE  "..\\gui\\graphics\\destroy-fx-link.png"
 implode-button.png  PNG DISCARDABLE  "..\\gui\\graphics\\implode-button.png"
 polarizer-background.png  PNG DISCARDABLE  "..\\gui\\graphics\\polarizer-background.png"
 slider-background.png  PNG DISCARDABLE  "..\\gui\\graphics\\slider-background.png"
 slider-handle.png  PNG DISCARDABLE  "..\\gui\\graphics\\slider-handle.png"
+
+bboron.ttf  DFX_TTF DISCARDABLE  "..\\..\\fonts\\bboron.ttf"

--- a/rezsynth/mac/rezsynth.xcodeproj/project.pbxproj
+++ b/rezsynth/mac/rezsynth.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		ECC480F625253A1D00CDC0EB /* iirfilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC0EF4742525022200864283 /* iirfilter.cpp */; };
 		ECDB2A6E21BA02AF00938F5C /* slider-handle-learn.png in Resources */ = {isa = PBXBuildFile; fileRef = 49BB475F07E53B4B00861708 /* slider-handle-learn.png */; };
 		ECDB2A6F21BA02B200938F5C /* vslider-handle-learn.png in Resources */ = {isa = PBXBuildFile; fileRef = 49BB476907E53B4B00861708 /* vslider-handle-learn.png */; };
+		ECF8587F25D2E4C000D92E27 /* px10.ttf in Resources */ = {isa = PBXBuildFile; fileRef = ECF8587E25D2E4C000D92E27 /* px10.ttf */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -207,6 +208,7 @@
 		ECC43128102F520F000B05A1 /* fr */ = {isa = PBXFileReference; fileEncoding = 10; lastKnownFileType = text.plist.strings; name = fr; path = "../../dfx-library/fr.lproj/dfx-au-utilities.strings"; sourceTree = "<group>"; };
 		ECC43129102F5219000B05A1 /* nl */ = {isa = PBXFileReference; fileEncoding = 10; lastKnownFileType = text.plist.strings; name = nl; path = "../../dfx-library/nl.lproj/dfx-au-utilities.strings"; sourceTree = "<group>"; };
 		ECD0B25120CC2FB3006CD7D1 /* de */ = {isa = PBXFileReference; fileEncoding = 10; lastKnownFileType = text.plist.strings; name = de; path = "../../dfx-library/de.lproj/dfx-au-utilities.strings"; sourceTree = "<group>"; };
+		ECF8587E25D2E4C000D92E27 /* px10.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = px10.ttf; path = ../../fonts/px10.ttf; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -263,6 +265,7 @@
 				4905A972067F716E00000F0C /* graphics */,
 				B028C2BB0D0F323700ADA1DA /* destroyfx.icns */,
 				ECC43125102F5208000B05A1 /* dfx-au-utilities.strings */,
+				ECF8587E25D2E4C000D92E27 /* px10.ttf */,
 			);
 			name = Resources;
 			sourceTree = "<group>";
@@ -555,6 +558,7 @@
 				ECC43127102F5208000B05A1 /* dfx-au-utilities.strings in Resources */,
 				ECC3B61412A6D62B00BA11D5 /* button-reson-algorithm.png in Resources */,
 				ECC3B6E412B0276200BA11D5 /* button-bandwidth-mode.png in Resources */,
+				ECF8587F25D2E4C000D92E27 /* px10.ttf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/rezsynth/win32/resources.rc
+++ b/rezsynth/win32/resources.rc
@@ -18,3 +18,5 @@ slider-handle-white.png  PNG DISCARDABLE  "..\\gui\\graphics\\slider-handle-whit
 slider-handle-yellow.png  PNG DISCARDABLE  "..\\gui\\graphics\\slider-handle-yellow.png"
 vslider-handle-green.png  PNG DISCARDABLE  "..\\gui\\graphics\\vslider-handle-green.png"
 vslider-handle-learn.png  PNG DISCARDABLE  "..\\gui\\graphics\\vslider-handle-learn.png"
+
+px10.ttf  DFX_TTF DISCARDABLE  "..\\..\\fonts\\px10.ttf"

--- a/scrubby/win32/resources.rc
+++ b/scrubby/win32/resources.rc
@@ -1,4 +1,3 @@
-
 all-notes-button.png  PNG DISCARDABLE  "..\\gui\\graphics\\all-notes-button.png"
 destroy-fx-link.png  PNG DISCARDABLE  "..\\gui\\graphics\\destroy-fx-link.png"
 freeze-button.png  PNG DISCARDABLE  "..\\gui\\graphics\\freeze-button.png"
@@ -36,3 +35,4 @@ tempo-sync-button.png  PNG DISCARDABLE  "..\\gui\\graphics\\tempo-sync-button.pn
 transpose-down-button.png  PNG DISCARDABLE  "..\\gui\\graphics\\transpose-down-button.png"
 transpose-up-button.png  PNG DISCARDABLE  "..\\gui\\graphics\\transpose-up-button.png"
 
+px10.ttf  DFX_TTF DISCARDABLE  "..\\..\\fonts\\px10.ttf"

--- a/skidder/mac/skidder.xcodeproj/project.pbxproj
+++ b/skidder/mac/skidder.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		ECE43DF12493BF55003C7957 /* range-slider-handle-right-learn.png in Resources */ = {isa = PBXBuildFile; fileRef = ECE43DE12493BF55003C7957 /* range-slider-handle-right-learn.png */; };
 		ECE43DF22493BF55003C7957 /* slider-background.png in Resources */ = {isa = PBXBuildFile; fileRef = ECE43DE22493BF55003C7957 /* slider-background.png */; };
 		ECE43DF42493BF55003C7957 /* slider-handle.png in Resources */ = {isa = PBXBuildFile; fileRef = ECE43DE42493BF55003C7957 /* slider-handle.png */; };
+		ECF8587C25D2E48800D92E27 /* px10.ttf in Resources */ = {isa = PBXBuildFile; fileRef = ECF8587B25D2E48800D92E27 /* px10.ttf */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -190,7 +191,7 @@
 		ECE43DD82493BF54003C7957 /* midi-learn-button.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "midi-learn-button.png"; sourceTree = "<group>"; };
 		ECE43DD92493BF54003C7957 /* range-slider-handle-left-learn.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "range-slider-handle-left-learn.png"; sourceTree = "<group>"; };
 		ECE43DDA2493BF54003C7957 /* midi-mode-button.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "midi-mode-button.png"; sourceTree = "<group>"; };
-		ECE43DDB2493BF55003C7957 /* background.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "background.png"; sourceTree = "<group>"; };
+		ECE43DDB2493BF55003C7957 /* background.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = background.png; sourceTree = "<group>"; };
 		ECE43DDC2493BF55003C7957 /* slider-handle-learn.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "slider-handle-learn.png"; sourceTree = "<group>"; };
 		ECE43DDD2493BF55003C7957 /* midi-reset-button.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "midi-reset-button.png"; sourceTree = "<group>"; };
 		ECE43DDE2493BF55003C7957 /* range-slider-handle-left.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "range-slider-handle-left.png"; sourceTree = "<group>"; };
@@ -199,6 +200,7 @@
 		ECE43DE12493BF55003C7957 /* range-slider-handle-right-learn.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "range-slider-handle-right-learn.png"; sourceTree = "<group>"; };
 		ECE43DE22493BF55003C7957 /* slider-background.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "slider-background.png"; sourceTree = "<group>"; };
 		ECE43DE42493BF55003C7957 /* slider-handle.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "slider-handle.png"; sourceTree = "<group>"; };
+		ECF8587B25D2E48800D92E27 /* px10.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = px10.ttf; path = ../../fonts/px10.ttf; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -255,6 +257,7 @@
 				EC11C848248C3E6B00FC4867 /* graphics */,
 				EC6CCD06248A06860048D27F /* dfx-au-utilities.strings */,
 				B028C2C60D0F324A00ADA1DA /* destroyfx.icns */,
+				ECF8587B25D2E48800D92E27 /* px10.ttf */,
 			);
 			name = Resources;
 			sourceTree = "<group>";
@@ -529,6 +532,7 @@
 				ECE43DE82493BF55003C7957 /* midi-learn-button.png in Resources */,
 				ECE43DEA2493BF55003C7957 /* midi-mode-button.png in Resources */,
 				ECE43DED2493BF55003C7957 /* midi-reset-button.png in Resources */,
+				ECF8587C25D2E48800D92E27 /* px10.ttf in Resources */,
 				ECE43DEE2493BF55003C7957 /* range-slider-handle-left.png in Resources */,
 				ECE43DE92493BF55003C7957 /* range-slider-handle-left-learn.png in Resources */,
 				ECE43DE72493BF55003C7957 /* range-slider-handle-right.png in Resources */,

--- a/skidder/win32/resources.rc
+++ b/skidder/win32/resources.rc
@@ -14,3 +14,5 @@ slider-handle-learn.png   PNG DISCARDABLE   "..\\gui\\graphics\\slider-handle-le
 slider-handle.png   PNG DISCARDABLE   "..\\gui\\graphics\\slider-handle.png"
 tempo-sync-button.png   PNG DISCARDABLE   "..\\gui\\graphics\\tempo-sync-button.png"
 velocity-button.png   PNG DISCARDABLE   "..\\gui\\graphics\\velocity-button.png"
+
+px10.ttf   DFX_TTF DISCARDABLE   "..\\..\\fonts\\px10.ttf"


### PR DESCRIPTION
… to embed in builds (also Geometer + Polarizer + Scrubby resource compiler files for Windows were lacking their fonts)