### PR TITLE
Windows: revive DLL versioning (fixes #22)

### DIFF
--- a/dfx-library/visualstudio/dfxplugin-version.rc
+++ b/dfx-library/visualstudio/dfxplugin-version.rc
@@ -1,5 +1,7 @@
 #include <winver.h>
 
+#include "../dfxdefines.h"
+
 
 /*
 #ifdef _WIN32

--- a/transverb/win32/makefile
+++ b/transverb/win32/makefile
@@ -47,7 +47,7 @@ VSTGUI_DEP_OBJECTS=$(MINGWLIB)/libopengl32.a $(MINGWLIB)/libole32.a $(MINGWLIB)/
 
 # embed png files.
 resources.o : resources.rc ../gui/graphics/*
-	$(WINDRES) -i resources.rc -o $@
+	$(WINDRES) $(DEFINES) -I $(DFXLIB) -i resources.rc -o $@
 
 dfx-transverb-64.dll : $(OBJECTS) $(PTHREAD_OBJECTS) $(VSTGUI_DEP_OBJECTS)
 	$(CXX) $(LFLAGS) -o $@ $^

--- a/transverb/win32/resources.rc
+++ b/transverb/win32/resources.rc
@@ -24,3 +24,6 @@ transverb-background.png        PNG  DISCARDABLE     "..\\gui\\graphics\\transve
 wide-fader-handle-glowing.png   PNG  DISCARDABLE     "..\\gui\\graphics\\wide-fader-handle-glowing.png"
 
 px10.ttf                        DFX_TTF  DISCARDABLE     "..\\..\\fonts\\px10.ttf"
+
+#include "../transverbdef.h"
+#include "../../dfx-library/visualstudio/dfxplugin-version.rc"


### PR DESCRIPTION
Does this resource-compile successfully with the mingw toolchain? And does it correctly show version+copyright details when you inspect "info" on the DLL file in Windows file explorer?