### PR TITLE
remove Snooty "font tweaks"

### DIFF
--- a/dfxgui/dfxguitextdisplay.h
+++ b/dfxgui/dfxguitextdisplay.h
@@ -31,17 +31,6 @@ To contact the author, use the contact form at http://destroyfx.org/
 
 #include "dfxguicontrol.h"
 
-namespace internal
-{
-// Some fonts have tweaks that we apply on a platform-by-platform basis
-// to get pixel-perfect alignment.
-enum class DGFontTweaks
-{
-	NONE,
-	SNOOTY10PX,
-	PASEMENT9PX,
-};
-}  // namespace internal
 
 //-----------------------------------------------------------------------------
 class DGTextDisplay : public DGControl<VSTGUI::CTextEdit>
@@ -88,7 +77,6 @@ public:
 protected:
 	void takeFocus() override;
 	void drawPlatformText(VSTGUI::CDrawContext* inContext, VSTGUI::IPlatformString* inString, VSTGUI::CRect const& inRegion) override;
-	VSTGUI::CRect platformGetSize() const override;
 
 	bool valueToTextProcBridge(float inValue, char outTextUTF8[kTextMaxLength], CParamDisplay* inUserData);
 	bool textToValueProcBridge(VSTGUI::UTF8StringPtr inText, float& outValue, VSTGUI::CTextEdit* textEdit);
@@ -101,7 +89,7 @@ protected:
 private:
 	static bool valueToTextProc_Generic(float inValue, char outTextUTF8[], void* inUserData);
 
-	internal::DGFontTweaks mFontTweaks = internal::DGFontTweaks::NONE;
+	bool const mIsBitmapFont;
 };
 
 
@@ -126,7 +114,7 @@ protected:
 	void drawPlatformText(VSTGUI::CDrawContext* inContext, VSTGUI::IPlatformString* inString, VSTGUI::CRect const& inRegion) override;
 
 private:
-  	internal::DGFontTweaks mFontTweaks = internal::DGFontTweaks::NONE;
+	bool const mIsBitmapFont;
 };
 
 

--- a/dfxgui/dfxguitextdisplay.h
+++ b/dfxgui/dfxguitextdisplay.h
@@ -33,6 +33,13 @@ To contact the author, use the contact form at http://destroyfx.org/
 
 
 //-----------------------------------------------------------------------------
+namespace detail
+{
+VSTGUI::CPoint GetTextViewPlatformOffset(char const* inFontName) noexcept;
+}
+
+
+//-----------------------------------------------------------------------------
 class DGTextDisplay : public DGControl<VSTGUI::CTextEdit>
 {
 public:

--- a/geometer/gui/geometereditor.cpp
+++ b/geometer/gui/geometereditor.cpp
@@ -124,6 +124,10 @@ GeometerHelpBox::GeometerHelpBox(DfxGuiEditor * inOwnerEditor, DGRect const & in
 			dfx::kFontSize_Snooty10px, DGColor::kBlack, dfx::kFontName_Snooty10px), 
    helpCategory(HELP_CATEGORY_GENERAL), itemNum(HELP_EMPTY)
 {
+  // HACK: duplicated from DGHelpBox (TODO: unify this code with DGHelpBox)
+  auto adjustedRegion = getViewSize();
+  adjustedRegion.offset(-detail::GetTextViewPlatformOffset(getFont()->getName()));
+  setViewSize(adjustedRegion, false);
 }
 
 //--------------------------------------------------------------------------
@@ -140,6 +144,8 @@ void GeometerHelpBox::draw(VSTGUI::CDrawContext * inContext) {
   DGRect textpos(getViewSize());
   textpos.setSize(textpos.getWidth() - 5, getFont()->getSize() + 2);
   textpos.offset(4, 1);
+  // HACK: duplicated from DGHelpBox (TODO: unify this code with DGHelpBox)
+  textpos.offset(detail::GetTextViewPlatformOffset(getFont()->getName()));
 
   auto const helpstrings = [this]() -> char const * {
     switch (helpCategory) {

--- a/geometer/gui/geometereditor.cpp
+++ b/geometer/gui/geometereditor.cpp
@@ -66,9 +66,9 @@ enum {
   pos_sliderincY = 35,
 
   pos_sliderlabelX = 19,
-  pos_sliderlabelY = pos_sliderY - 1,
+  pos_sliderlabelY = pos_sliderY - 3,
   pos_sliderlabelwidth = 32,
-  pos_sliderlabelheight = 10,
+  pos_sliderlabelheight = 12,
 
   pos_finedownX = 27,
   pos_finedownY = 263,
@@ -77,7 +77,7 @@ enum {
   pos_finebuttonincX = 240,
   pos_finebuttonincY = pos_sliderincY,
 
-  pos_displayheight = 10,
+  pos_displayheight = 12,
   pos_displayX = 180,
   pos_displayY = pos_sliderY - pos_displayheight,
   pos_displaywidth = pos_sliderX + pos_sliderwidth - pos_displayX,
@@ -138,8 +138,8 @@ void GeometerHelpBox::draw(VSTGUI::CDrawContext * inContext) {
     image->draw(inContext, getViewSize());
 
   DGRect textpos(getViewSize());
-  textpos.setSize(textpos.getWidth() - 5, 10);
-  textpos.offset(4, 3);
+  textpos.setSize(textpos.getWidth() - 5, getFont()->getSize() + 2);
+  textpos.offset(4, 1);
 
   auto const helpstrings = [this]() -> char const * {
     switch (helpCategory) {

--- a/rezsynth/gui/rezsyntheditor.cpp
+++ b/rezsynth/gui/rezsyntheditor.cpp
@@ -41,7 +41,7 @@ enum
 	kHorizontalSliderHeight = 23,
 
 	kHorizontalDisplayWidth = kHorizontalSliderWidth / 2,
-	kHorizontalDisplayHeight = 10,
+	kHorizontalDisplayHeight = 12,
 	kHorizontalDisplayX = kHorizontalSliderX + kHorizontalSliderWidth - kHorizontalDisplayWidth - 3,
 	kHorizontalDisplayY = kHorizontalSliderY - kHorizontalDisplayHeight,
 
@@ -53,7 +53,7 @@ enum
 	kVerticalSliderNameWidth = 13,
 
 	kVerticalDisplayX = kVerticalSliderX - 21,
-	kVerticalDisplayY = kVerticalSliderY + kVerticalSliderHeight + 11,
+	kVerticalDisplayY = kVerticalSliderY + kVerticalSliderHeight + 9,
 	kVerticalDisplayWidth = 48,
 	kVerticalDisplayHeight = kHorizontalDisplayHeight,
 
@@ -378,7 +378,7 @@ long RezSynthEditor::OpenEditor()
 	// help display
 	pos.set(kHelpX, kHelpY, kHelpWidth, kHelpHeight);
 	mHelpBox = emplaceControl<DGHelpBox>(this, pos, std::bind(&RezSynthEditor::GetHelpForControl, this, std::placeholders::_1), nullptr, DGColor::kWhite);
-	mHelpBox->setTextMargin({11, 8});
+	mHelpBox->setTextMargin({11, 6});
 
 
 

--- a/scrubby/gui/scrubbyeditor.cpp
+++ b/scrubby/gui/scrubbyeditor.cpp
@@ -78,7 +78,7 @@ enum
 
 	kDisplayWidth = 90,
 	kDisplayWidth_big = 117,  // for seek rate
-	kDisplayHeight = 10,
+	kDisplayHeight = 12,
 	kDisplayInsetX = 0,
 	kDisplayInsetX_leftAlign = 2,
 	kDisplayInsetY = 0,
@@ -522,7 +522,7 @@ long ScrubbyEditor::OpenEditor()
 	pos.set(kHelpX, kHelpY, helpBackgroundImage->getWidth(), helpBackgroundImage->getHeight());
 	mHelpBox = emplaceControl<DGHelpBox>(this, pos, std::bind(&ScrubbyEditor::GetHelpForControl, this, _1), helpBackgroundImage, DGColor::kWhite);
 	mHelpBox->setHeaderFontColor(DGColor::kBlack);
-	mHelpBox->setTextMargin({12, 4});
+	mHelpBox->setTextMargin({12, 2});
 
 
 

--- a/skidder/gui/skiddereditor.cpp
+++ b/skidder/gui/skiddereditor.cpp
@@ -46,7 +46,7 @@ enum
 	kSliderInc = 64,
 
 	kDisplayX = 334,
-	kDisplayY = kSliderY + 11,
+	kDisplayY = kSliderY + 10,
 	kDisplayWidth = 70,
 	kDisplayHeight = 12,
 
@@ -297,7 +297,7 @@ long SkidderEditor::OpenEditor()
 	// help display
 	pos.set(kHelpX, kHelpY, kHelpWidth, kHelpHeight);
 	mHelpBox = emplaceControl<DGHelpBox>(this, pos, std::bind(&SkidderEditor::GetHelpForControl, this, std::placeholders::_1), nullptr, DGColor::kWhite);
-	mHelpBox->setTextMargin({8, 12});
+	mHelpBox->setTextMargin({8, 10});
 	mHelpBox->setLineSpacing(3);
 
 

--- a/transverb/gui/transverbeditor.cpp
+++ b/transverb/gui/transverbeditor.cpp
@@ -47,6 +47,11 @@ enum
 	kTallFaderY = 265,
 	kTallFaderInc = 28,
 
+	kDisplayX = 318 + 1,
+	kDisplayWidth = 180,
+	kDisplayHeight = 12,
+	kDisplayY = kWideFaderY - kDisplayHeight - 1,
+
 	kQualityButtonX = 425,
 	kTomsoundButtonX = kQualityButtonX,
 	kFreezeButtonX = kWideFaderX,
@@ -68,12 +73,7 @@ enum
 	kDFXLinkX = 107,
 	kDFXLinkY = 281,
 	kDestroyFXLinkX = 351,
-	kDestroyFXLinkY = 339,
-
-	kDisplayX = 318 + 1,
-	kDisplayY = 24,
-	kDisplayWidth = 180,
-	kDisplayHeight = 10
+	kDestroyFXLinkY = 339
 };
 
 


### PR DESCRIPTION
Alright I spent some time deconstructing the Snooty font tweaks, why they were needed, what they did, super advanced math measuring pixel positions and whatnot, because I thought you were probably right they we should just offload whatever layout requirements to the client code.  The crux of the remaining font tweaks came down to two things:
* Despite being 10px, 10 pixels is not enough vertical space to draw them without the descenders being clipped. 11 pixel region seems to be the minimum. This may just be a VSTGUI quirk, I don't know, but for extra safety, I changed every use of Snooty to use a 12 pixel region height, so no more tweaks for that needed in DGTextDisplay.
* The other issue is that, when entering text edit, the text position jumps upwards a couple of pixels. This is not unique to Snooty but happens with our plugs that use other fonts too, so maybe another VSTGUI quirk, maybe a platform text edit field quirk, I don't know, but with minimum 12-pixel regions, it's not an issue.

So if we just always give Snooty 12 pixels of height in which to draw, it's happy and all of the hackz become unnecessary. At least on my Mac. I have opened this pull request to give a holding pen for you to see whether this approach is also working okay for you on Windows!