### PR TITLE
Transverb: add inline help via tooltips

### DIFF
--- a/dfxgui/dfxguieditor.cpp
+++ b/dfxgui/dfxguieditor.cpp
@@ -31,8 +31,8 @@ To contact the author, use the contact form at http://destroyfx.org/
 #include <functional>
 #include <locale>
 #include <mutex>
-#include <type_traits>
 #include <string_view>
+#include <type_traits>
 
 #include "dfxguibutton.h"
 #include "dfxguidialog.h"
@@ -749,6 +749,18 @@ void DfxGuiEditor::TextEntryForParameterValue(long inParameterID)
 		if (!mTextEntryDialog->runModal(getFrame(), textEntryCallback))
 		{
 			ShowMessage("could not display text entry dialog");
+		}
+	}
+}
+
+//-----------------------------------------------------------------------------
+void DfxGuiEditor::SetParameterHelpText(long inParameterID, char const* inText)
+{
+	for (auto& control : mControlsList)
+	{
+		if (control->getParameterID() == inParameterID)
+		{
+			control->setHelpText(inText);
 		}
 	}
 }
@@ -2900,7 +2912,7 @@ void DfxGuiEditor::RestoreVSTStateFromProgramFile(char const* inFilePath)
 		auto const amountRead = fileStream->readRaw(buffer, size);
 		Require(amountRead == size, "failed to read enough file data");
 	};
-	auto const requireReadCompletion = [&fileStream]()
+	auto const requireReadCompletion = [&fileStream]
 	{
 		Require(fileStream->tell() == fileStream->seek(0, VSTGUI::SeekMode::End), 
 				"file contains unexpected excess data");

--- a/dfxgui/dfxguieditor.h
+++ b/dfxgui/dfxguieditor.h
@@ -283,6 +283,7 @@ public:
 	bool dfxgui_SetParameterValueWithString(long inParameterID, std::string const& inText);
 	bool dfxgui_IsValidParamID(long inParameterID);
 	void TextEntryForParameterValue(long inParameterID);
+	void SetParameterHelpText(long inParameterID, char const* inText);
 	void SetParameterAlpha(long inParameterID, float inAlpha);
 #ifdef TARGET_API_AUDIOUNIT
 	AudioUnitParameter dfxgui_MakeAudioUnitParameter(AudioUnitParameterID inParameterID, AudioUnitScope inScope = kAudioUnitScope_Global, AudioUnitElement inElement = 0);

--- a/transverb/gui/transverbeditor.cpp
+++ b/transverb/gui/transverbeditor.cpp
@@ -367,6 +367,7 @@ long TransverbEditor::OpenEditor()
 			displayProc = distDisplayProcedure;
 			userData = this;
 		}
+		assert(displayProc);
 		emplaceControl<DGSlider>(this, tag, pos, dfx::kAxis_Horizontal, horizontalSliderHandleImage, horizontalSliderBackgroundImage, sliderRangeMargin)->setAlternateHandle(horizontalSliderHandleImage_glowing);
 
 		auto const textDisplay = emplaceControl<DGTextDisplay>(this, tag, textDisplayPos, displayProc, userData, nullptr,
@@ -464,6 +465,25 @@ long TransverbEditor::OpenEditor()
 	// Super Destroy FX web link
 	pos.set(kDestroyFXLinkX, kDestroyFXLinkY, destroyFXLinkButtonImage->getWidth(), destroyFXLinkButtonImage->getHeight() / 2);
 	emplaceControl<DGWebLink>(this, pos, destroyFXLinkButtonImage, DESTROYFX_URL);
+
+
+	SetParameterHelpText(kBsize, "the size of the buffer that both delays use");
+	constexpr char const* const speedHelpText = "how quickly or slowly the delay playback moves through the delay buffer";
+	SetParameterHelpText(kSpeed1, speedHelpText);
+	SetParameterHelpText(kSpeed2, speedHelpText);
+	std::for_each(mSpeedModeButtons.begin(), mSpeedModeButtons.end(), [](auto* control){ control->setHelpText(speedHelpText); });
+	constexpr char const* const feedbackHelpText = "how much of the delay sound gets mixed back into the delay buffer";
+	SetParameterHelpText(kFeed1, feedbackHelpText);
+	SetParameterHelpText(kFeed2, feedbackHelpText);
+	constexpr char const* const distanceHelpText = "how far behind the delay is from the input signal (only really makes a difference when the speed is at zero)";
+	SetParameterHelpText(kDist1, distanceHelpText);
+	SetParameterHelpText(kDist2, distanceHelpText);
+	SetParameterHelpText(kDrymix, "input audio mix level");
+	SetParameterHelpText(kMix1, "delay head #1 mix level");
+	SetParameterHelpText(kMix2, "delay head #2 mix level");
+	SetParameterHelpText(kQuality, "level of transposition quality of the delays' speed");
+	SetParameterHelpText(kTomsound, "megaharsh sound");
+	SetParameterHelpText(kFreeze, "pause recording new audio into the delay buffer");
 
 
 	return dfx::kStatus_NoError;


### PR DESCRIPTION
I recently remembered we have tooltip support in DFXGUI. What do you think of adding built-in help to Transverb with this? Helpful? Annoying?