### PR TITLE
Transverb: adapt to "distance" changes without crackly glitches

### DIFF
--- a/transverb/gui/transverbeditor.cpp
+++ b/transverb/gui/transverbeditor.cpp
@@ -474,6 +474,12 @@ void TransverbEditor::OpenEditor()
 	SetParameterHelpText(kQuality, "level of transposition quality of the delays' speed");
 	SetParameterHelpText(kTomsound, "megaharsh sound");
 	SetParameterHelpText(kFreeze, "pause recording new audio into the delay buffer");
+
+
+#if 1
+	pos.set(120, getFrame()->getHeight() - 24, 210, 16);
+	emplaceControl<DGPopUpMenu>(this, kDistChangeMode, pos, dfx::TextAlignment::Center, kDisplayTextSize, VSTGUI::MakeCColor(92, 151, 209), kDisplayFont);
+#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/transverb/transverb-base.h
+++ b/transverb/transverb-base.h
@@ -48,6 +48,7 @@ enum : dfx::ParameterID
 	kTomsound,
 	kFreeze,
 	kAttenuateFeedbackByMixLevel,
+	kDistChangeMode,
 
 	kNumParameters
 };
@@ -65,6 +66,8 @@ enum { kQualityMode_DirtFi, kQualityMode_HiFi, kQualityMode_UltraHiFi, kQualityM
 // this stuff is for the speed parameter adjustment mode switch on the GUI
 enum : unsigned int { kSpeedMode_Fine, kSpeedMode_Semitone, kSpeedMode_Octave, kSpeedMode_NumModes };
 static constexpr dfx::PropertyID kTransverbProperty_SpeedModeBase = dfx::kPluginProperty_EndOfList;
+
+enum { kDistChangeMode_Reverse, kDistChangeMode_AdHocVarispeed, kDistChangeMode_DistanceVarispeed, kDistChangeMode_BufferVarispeed, kDistChangeMode_LoopingBufferVarispeed, kDistChangeMode_Count };
 
 
 dfx::PropertyID speedModeIndexToPropertyID(size_t inIndex) noexcept;

--- a/transverb/transverb.h
+++ b/transverb/transverb.h
@@ -26,6 +26,7 @@ To contact the author, use the contact form at http://destroyfx.org
 #include <cmath>
 #include <cstdint>
 #include <numeric>
+#include <optional>
 #include <span>
 #include <vector>
 
@@ -59,6 +60,8 @@ private:
     dfx::SmoothedValue<float> mix, feed;
 
     double read = 0.;
+    std::optional<double> targetdist;
+    double distspeedfactor = 1.;
     std::vector<float> buf;
 
     dfx::IIRFilter filter;
@@ -85,14 +88,22 @@ private:
   static constexpr int mod_bipolar(int value, int modulo) noexcept DFX_RT_ATTR;
   static inline double fmod_bipolar(double value, double modulo) noexcept DFX_RT_ATTR;
 
+  // distance in samples of a read position from the current write position
+  double getdist(double read) const noexcept DFX_RT_ATTR;
+  void processdist(double distnormalized, Head& head) noexcept DFX_RT_ATTR;
+
   // these store the parameter values
   int bsize = 0;
   dfx::SmoothedValue<float> drymix;
+  int distchangemode {};
 
   int writer = 0;
   std::array<Head, dfx::TV::kNumDelays> heads;
 
   int const MAXBUF;  // the size of the audio buffer (dependent on sampling rate)
+
+  bool firstrendersincereset = false;
+  std::vector<float>& buftemp;
 
   std::vector<float> const firCoefficientsWindow;
 };
@@ -116,6 +127,10 @@ public:
   dfx::StatusCode dfx_SetProperty(dfx::PropertyID inPropertyID, dfx::Scope inScope, unsigned int inItemIndex,
                                   void const* inData, size_t inDataSize) override;
 
+  auto& getscratchbuffer() noexcept DFX_RT_ATTR {
+    return buftemp;
+  }
+
 protected:
   size_t settings_sizeOfExtendedData() const noexcept override;
   void settings_saveExtendedData(void* outData, bool isPreset) const override;
@@ -132,6 +147,7 @@ private:
   }
 
   std::array<uint32_t, dfx::TV::kNumDelays> speedModeStates {};
+  std::vector<float> buftemp;  // shared between all DSP cores (memory optimization)
 };
 
 

--- a/transverb/transverbformalities.cpp
+++ b/transverb/transverbformalities.cpp
@@ -57,6 +57,7 @@ Transverb::Transverb(TARGET_API_BASE_INSTANCE_TYPE inInstance)
   initparameter_b(kTomsound, {"TOMSOUND", "TomSnd", "Tom7"}, false);
   initparameter_b(kFreeze, {dfx::kParameterNames_Freeze}, false);
   initparameter_b(kAttenuateFeedbackByMixLevel, {"attenuate feedback by mix level", "AtnFdbk", "AtnFdb", "-fdb"}, false);
+  initparameter_list(kDistChangeMode, {"distance change mode", "DistMod", "DstMod", "DMod"}, kDistChangeMode_Reverse, kDistChangeMode_Reverse, kDistChangeMode_Count);
 
   setparameterenforcevaluelimits(kBsize, true);
   for (auto const parameterID : kDistParameters) {
@@ -67,10 +68,12 @@ Transverb::Transverb(TARGET_API_BASE_INSTANCE_TYPE inInstance)
   setparametervaluestring(kQuality, kQualityMode_HiFi, "hi-fi");
   setparametervaluestring(kQuality, kQualityMode_UltraHiFi, "ultra hi-fi");
 
-  // distance parameters only have meaningful effect at zero speed which probably will never occur randomly,
-  // and otherwise all they do is glitch a lot, so omit them
-  addparameterattributes(kDist1, DfxParam::kAttribute_OmitFromRandomizeAll);
-  addparameterattributes(kDist2, DfxParam::kAttribute_OmitFromRandomizeAll);
+  setparametervaluestring(kDistChangeMode, kDistChangeMode_Reverse, "reverse");
+  setparametervaluestring(kDistChangeMode, kDistChangeMode_AdHocVarispeed, "ad hoc varispeed");
+  setparametervaluestring(kDistChangeMode, kDistChangeMode_DistanceVarispeed, "distance varispeed");
+  setparametervaluestring(kDistChangeMode, kDistChangeMode_BufferVarispeed, "buffer varispeed");
+  setparametervaluestring(kDistChangeMode, kDistChangeMode_LoopingBufferVarispeed, "looping buffer varispeed");
+
   addparameterattributes(kFreeze, DfxParam::kAttribute_OmitFromRandomizeAll);
   addparameterattributes(kAttenuateFeedbackByMixLevel, DfxParam::kAttribute_OmitFromRandomizeAll);
 
@@ -109,7 +112,10 @@ void Transverb::dfx_PostConstructor() {
 TransverbDSP::TransverbDSP(DfxPlugin& inDfxPlugin)
   : DfxPluginCore(inDfxPlugin),
     MAXBUF(static_cast<int>(getparametermax_f(kBsize) * 0.001 * getsamplerate())),
+    buftemp(dynamic_cast<Transverb&>(inDfxPlugin).getscratchbuffer()),
     firCoefficientsWindow(dfx::FIRFilter::generateKaiserWindow(kNumFIRTaps, 60.0f)) {
+
+  buftemp.assign(MAXBUF, 0.f);
 
   registerSmoothedAudioValue(drymix);
 
@@ -126,12 +132,15 @@ TransverbDSP::TransverbDSP(DfxPlugin& inDfxPlugin)
 void TransverbDSP::reset() noexcept DFX_RT_ATTR {
 
   std::ranges::for_each(heads, [](Head& head) DFX_RT_LAMBDA { head.reset(); });
+
+  firstrendersincereset = true;
 }
 
 void TransverbDSP::Head::reset() noexcept DFX_RT_ATTR {
 
   smoothcount = 0;
   lastdelayval = 0.f;
+  targetdist.reset();
   filter.reset();
   speedHasChanged = true;
 
@@ -191,12 +200,12 @@ void TransverbDSP::processparameters() noexcept DFX_RT_ATTR {
     std::ranges::for_each(heads, [bsize_f](Head& head) DFX_RT_LAMBDA { head.read = fmod_bipolar(head.read, bsize_f); });
   }
 
+  distchangemode = getparameter_i(kDistChangeMode);
   for (size_t head = 0; head < kNumDelays; head++)
   {
     if (auto const dist = getparameterifchanged_f(kDistParameters[head]))
     {
-      auto const bsize_f = static_cast<double>(bsize);
-      heads[head].read = fmod_bipolar(static_cast<double>(writer) - (*dist * bsize_f), bsize_f);
+      processdist(*dist, heads[head]);
     }
   }
 
@@ -217,6 +226,64 @@ void TransverbDSP::processparameters() noexcept DFX_RT_ATTR {
     else if (GetChannelNum() == 1)
     {
       heads[0].mix.setValueNow(getparametermin_f(kMix1));
+    }
+  }
+
+  firstrendersincereset = false;
+}
+
+double TransverbDSP::getdist(double read) const noexcept DFX_RT_ATTR {
+
+  return fmod_bipolar(static_cast<double>(writer) - read, static_cast<double>(bsize));
+}
+
+void TransverbDSP::processdist(double distnormalized, Head& head) noexcept DFX_RT_ATTR {
+
+  auto const bsize_f = static_cast<double>(bsize);
+  auto const distsamples = distnormalized * bsize_f;
+  auto const targetread = fmod_bipolar(static_cast<double>(writer) - distsamples, bsize_f);
+
+  if (firstrendersincereset)
+  {
+    head.read = targetread;
+  }
+  else
+  {
+    if (distchangemode == kDistChangeMode_Reverse)
+    {
+      head.targetdist = distsamples;
+    }
+    else if (auto const resamplerate = getdist(head.read) / std::max(distsamples, 1.); distchangemode == kDistChangeMode_AdHocVarispeed)
+    {
+      head.targetdist = distsamples;
+      head.distspeedfactor = resamplerate;
+      head.speedHasChanged = true;
+    }
+    else
+    {
+      constexpr double modulationthresholdsamples = 1.;
+      if (std::fabs(targetread - head.read) >= modulationthresholdsamples)
+      {
+        auto const bsizesteps = bsize_f / resamplerate;
+        bool const subslice = (distchangemode == kDistChangeMode_DistanceVarispeed);
+        bool const looping = (distchangemode == kDistChangeMode_LoopingBufferVarispeed);
+        auto const copylength_f = subslice ? distsamples : (looping ? bsize_f : std::min(bsize_f, bsizesteps));
+        auto const copylength = static_cast<size_t>(std::lround(copylength_f));
+        DFX_RT_ASSERT(copylength <= buftemp.size());
+        DFX_RT_ASSERT(static_cast<int>(copylength) <= bsize);
+        auto const sourcestart = subslice ? head.read : fmod_bipolar(static_cast<double>(writer) - (copylength_f * resamplerate), bsize_f);
+        for (size_t i = 0; i < copylength; i++)
+        {
+          auto const sourcepos = std::fmod(sourcestart + (resamplerate * static_cast<double>(i)), bsize_f);
+          buftemp[i] = interpolateHermite(head.buf.data(), sourcepos, bsize, writer);
+        }
+        auto const destinationstart = subslice ? std::lround(targetread) : mod_bipolar(writer - static_cast<int>(copylength), bsize);
+        auto const copylength1 = std::min(static_cast<size_t>(bsize - destinationstart), copylength);
+        auto const copylength2 = copylength - copylength1;
+        std::copy_n(buftemp.cbegin(), copylength1, std::next(head.buf.begin(), destinationstart));
+        std::copy_n(std::next(buftemp.cbegin(), copylength1), copylength2, head.buf.begin());
+      }
+      head.read = targetread;
     }
   }
 }

--- a/transverb/transverbprocess.cpp
+++ b/transverb/transverbprocess.cpp
@@ -37,13 +37,13 @@ using namespace dfx::TV;
 void TransverbDSP::process(std::span<float const> inAudio,
                            std::span<float> outAudio) noexcept DFX_RT_ATTR {
 
-  std::array<float, kNumDelays> delayvals {};  // delay buffer output values
   auto const bsize_float = static_cast<double>(bsize);  // cut down on casting
   auto const quality = getparameter_i(kQuality);
   auto const tomsound = getparameter_b(kTomsound);
   auto const freeze = getparameter_b(kFreeze);
   int const writerIncrement = freeze ? 0 : 1;
   auto const attenuateFeedbackByMixLevel = getparameter_b(kAttenuateFeedbackByMixLevel);
+  std::array<float, kNumDelays> delayvals {};  // delay buffer output values
 
 
   /////////////   S O P H I A S O U N D   //////////////
@@ -72,6 +72,9 @@ void TransverbDSP::process(std::span<float const> inAudio,
       for (size_t h = 0; h < kNumDelays; h++)  // delay heads loop
       {
         auto const read_int = static_cast<int>(heads[h].read);
+        auto const reverseread = (distchangemode == kDistChangeMode_Reverse) && heads[h].targetdist.has_value();
+        auto const distcatchup = (distchangemode == kDistChangeMode_AdHocVarispeed) && heads[h].targetdist.has_value();
+        auto const speed = heads[h].speed.getValue() * (distcatchup ? heads[h].distspeedfactor : 1.);
 
         // filter setup
         if (quality == kQualityMode_UltraHiFi)
@@ -80,27 +83,27 @@ void TransverbDSP::process(std::span<float const> inAudio,
           {
             lowpasspos[h] = read_int;
             // check to see if we need to lowpass the first delay head and init coefficients if so
-            if (heads[h].speed.getValue() > kUnitySpeed)
+            if (speed > kUnitySpeed)
             {
               filtermodes[h] = FilterMode::LowpassIIR;
-              speed_ints[h] = static_cast<int>(heads[h].speed.getValue());
+              speed_ints[h] = static_cast<int>(speed);
               // it becomes too costly to try to IIR at higher speeds, so switch to FIR filtering
-              if (heads[h].speed.getValue() >= kFIRSpeedThreshold)
+              if (speed >= kFIRSpeedThreshold)
               {
                 filtermodes[h] = FilterMode::LowpassFIR;
                 // compensate for gain lost from filtering
-                mugs[h] = static_cast<float>(std::pow(heads[h].speed.getValue() / kFIRSpeedThreshold, 0.78));
+                mugs[h] = static_cast<float>(std::pow(speed / kFIRSpeedThreshold, 0.78));
                 // update the coefficients only if necessary
                 if (std::exchange(heads[h].speedHasChanged, false))
                 {
-                  dfx::FIRFilter::calculateIdealLowpassCoefficients((samplerate / heads[h].speed.getValue()) * dfx::FIRFilter::kShelfStartLowpass,
+                  dfx::FIRFilter::calculateIdealLowpassCoefficients((samplerate / speed) * dfx::FIRFilter::kShelfStartLowpass,
                                                                     samplerate, heads[h].firCoefficients, firCoefficientsWindow);
                   heads[h].filter.reset();
                 }
               }
               else if (std::exchange(heads[h].speedHasChanged, false))
               {
-                heads[h].filter.setLowpassCoefficients((samplerate / heads[h].speed.getValue()) * dfx::IIRFilter::kShelfStartLowpass);
+                heads[h].filter.setLowpassCoefficients((samplerate / speed) * dfx::IIRFilter::kShelfStartLowpass);
               }
             }
             // we need to highpass the delay head to remove mega sub bass
@@ -109,7 +112,7 @@ void TransverbDSP::process(std::span<float const> inAudio,
               filtermodes[h] = FilterMode::Highpass;
               if (std::exchange(heads[h].speedHasChanged, false))
               {
-                heads[h].filter.setHighpassCoefficients(kHighpassFilterCutoff / heads[h].speed.getValue());
+                heads[h].filter.setHighpassCoefficients(kHighpassFilterCutoff / speed);
               }
             }
           }
@@ -176,18 +179,18 @@ void TransverbDSP::process(std::span<float const> inAudio,
         // start smoothing if the writer has passed a reader or vice versa,
         // though not if reader and writer move at the same speed
         // (check the positions before wrapping around the heads)
-        auto const nextRead = static_cast<int>(heads[h].read + heads[h].speed.getValue());
+        auto const nextRead = static_cast<int>(heads[h].read + speed);
         auto const nextWrite = writer + 1;
         bool const readCrossingAhead = (read_int < writer) && (nextRead >= nextWrite);
         bool const readCrossingBehind = (read_int >= writer) && (nextRead <= nextWrite);
-        bool const speedIsUnity = heads[h].speed.getValue() == kUnitySpeed;
+        bool const speedIsUnity = (speed == kUnitySpeed);
         if ((readCrossingAhead || readCrossingBehind) && !speedIsUnity) {
           // check because, at slow speeds, it's possible to go into this twice or more in a row
           if (heads[h].smoothcount <= 0) {
             // store the most recent output as the head's smoothing sample
             heads[h].lastdelayval = delayvals[h];
             // truncate the smoothing duration if we're using too small of a buffer size
-            auto const bufferReadSteps = static_cast<int>(bsize_float / heads[h].speed.getValue());
+            auto const bufferReadSteps = static_cast<int>(bsize_float / speed);
             auto const smoothdur = std::min(bufferReadSteps, kAudioSmoothingDur_samples);
             heads[h].smoothstep = 1.f / static_cast<float>(smoothdur);  // the scalar step value
             heads[h].smoothcount = smoothdur;  // set the counter to the total duration
@@ -195,9 +198,21 @@ void TransverbDSP::process(std::span<float const> inAudio,
         }
 
         // update read heads, wrapping around if they have gone past the end of the buffer
-        heads[h].read += heads[h].speed.getValue();
-        if (heads[h].read >= bsize_float) {
-          heads[h].read = fmod_bipolar(heads[h].read, bsize_float);
+        if (reverseread) {
+          heads[h].read -= speed;
+          while (heads[h].read < 0.) {
+            heads[h].read += bsize_float;
+          }
+        } else {
+          heads[h].read += speed;
+          if (heads[h].read >= bsize_float) {
+            heads[h].read = std::fmod(heads[h].read, bsize_float);
+          }
+        }
+        if (distcatchup || reverseread) {
+          if (std::fabs(getdist(heads[h].read) - *heads[h].targetdist) < speed) {
+            heads[h].targetdist.reset();
+          }
         }
 
         // if we're doing IIR lowpass filtering,
@@ -207,40 +222,47 @@ void TransverbDSP::process(std::span<float const> inAudio,
         if (filtermodes[h] == FilterMode::LowpassIIR)
         {
           int lowpasscount = 0;
+          int const direction = reverseread ? -1 : 1;
           while (lowpasscount < speed_ints[h])
           {
             switch (speed_ints[h] - lowpasscount)
             {
               case 1:
                 heads[h].filter.processToCacheH1(heads[h].buf[lowpasspos[h]]);
-                lowpasspos[h] = (lowpasspos[h] + 1) % bsize;
+                lowpasspos[h] = mod_bipolar(lowpasspos[h] + (1 * direction), bsize);
                 lowpasscount++;
                 break;
               case 2:
                 heads[h].filter.processToCacheH2(std::span(heads[h].buf).subspan(0, bsize), dfx::math::ToUnsigned(lowpasspos[h]));
-                lowpasspos[h] = (lowpasspos[h] + 2) % bsize;
+                lowpasspos[h] = mod_bipolar(lowpasspos[h] + (2 * direction), bsize);
                 lowpasscount += 2;
                 break;
               case 3:
                 heads[h].filter.processToCacheH3(std::span(heads[h].buf).subspan(0, bsize), dfx::math::ToUnsigned(lowpasspos[h]));
-                lowpasspos[h] = (lowpasspos[h] + 3) % bsize;
+                lowpasspos[h] = mod_bipolar(lowpasspos[h] + (3 * direction), bsize);
                 lowpasscount += 3;
                 break;
               default:
                 heads[h].filter.processToCacheH4(std::span(heads[h].buf).subspan(0, bsize), dfx::math::ToUnsigned(lowpasspos[h]));
-                lowpasspos[h] = (lowpasspos[h] + 4) % bsize;
+                lowpasspos[h] = mod_bipolar(lowpasspos[h] + (4 * direction), bsize);
                 lowpasscount += 4;
                 break;
             }
           }
           auto const nextread_int = static_cast<int>(heads[h].read);
           // check whether we need to consume one more sample
-          bool const extrasample = ((lowpasspos[h] < nextread_int) && ((lowpasspos[h] + 1) == nextread_int)) ||
-                                   ((lowpasspos[h] == (bsize - 1)) && (nextread_int == 0));
+          bool const extrasample = [=, this] DFX_RT_LAMBDA {
+            if (reverseread) {
+              return ((lowpasspos[h] > nextread_int) && ((lowpasspos[h] - 1) == nextread_int)) ||
+                     ((lowpasspos[h] == 0) && (nextread_int == (bsize - 1)));
+            }
+            return ((lowpasspos[h] < nextread_int) && ((lowpasspos[h] + 1) == nextread_int)) ||
+                   ((lowpasspos[h] == (bsize - 1)) && (nextread_int == 0));
+          }();
           if (extrasample)
           {
             heads[h].filter.processToCacheH1(heads[h].buf[lowpasspos[h]]);
-            lowpasspos[h] = (lowpasspos[h] + 1) % bsize;
+            lowpasspos[h] = mod_bipolar(lowpasspos[h] + (1 * direction), bsize);
           }
         }
         // it's simpler for highpassing;


### PR DESCRIPTION
Here is my collection of prototypes of different approach to deal with "distance" parameter changes in a more sonically interesting manor. My goals are for it to:
1. no longer glitch in an uninteresting way (just sounding like a crummy bug)
2. do something actually interesting/fun sounding instead

Here there is a new (temporary) parameter for "distance change mode" that let's you choose between five algorithms:

**reverse**
Move playhead in reverse until reaching the new distance.

**distance varispeed**
In the buffer, take the period of audio between the current read position to the write position and resample it (stretching or compressing the length as needed) to last the duration of the new "distance" setting, and then copy that resampled audio to the delay buffer between the newly distanced read position and the write position.
The idea inspiring this is the way that analog bucket brigade delays work, where they behave as though they are operating with a fixed storage for the delay audio, and when you lower the delay time, then the same storage is used in full but at a faster rate, so whatever was already in the delay buffer now is pitched higher, but new incoming audio delays at regular speed. And conversely increasing the delay time slows down the existing audio in the delay buffer. for example: (https://www.youtube.com/watch?v=KSaZEqfy0ac&t=1171)

**buffer varispeed**
Like distance varispeed, but do that transformation to the entire buffer, not just the segment between reader and writer.

**looping buffer varispeed**
Like buffer varispeed, except that in the case where the distance change is shortening, resampling the entire buffer does not provide enough resampled audio to refill the whole buffer, so keep looping that resampled audio as much as needed for the output to fill the buffer.

**ad hoc varispeed**
Taking the same resampling rate as used in the previous varispeed modes, rather than rewriting the buffer, offset the active delay head speed with that resampling rate for as long as it takes to reach the target distance.

I am curious to hear your opinions of these! And I will share mine, plus some other findings:

I think that reverse really only succeeds at the goal of eliminating glitches, but it isn't that especially fun or interesting sounding.

I was really happy after implementing distance varispeed, but it was usually glitching at the start of the resampling. I thought that maybe rounding errors for partial sample read positions, or the resampling algorithm that looks back and forward, might not like that new transformation boundary right at the read head, and lead me to implement buffer varispeed. And then looping buffer varispeed as a logical extension.

The buffer resampling algorithms are definitely my favorite sounding. They can get pretty enjoyably chaotic and unpredictable as you move the distance parameter around because the buffer resampling compounds on itself, differently in segments of the buffer upon each change. But then I looked at the CPU meter and saw it peaking while dragging the distance slider around. It depends how big your buffer parameter is set in Transverb, and also what the general audio processing buffer size for plugins is in your hold (small Transverb buffer sizes are less of a hit, and larger host buffer sizes make the hit easier to absorb). This also points to the fact that, if you are dragging the parameter around over time, you will get decidedly different audio results depending on what the host buffer size is, which I don't love.

Much as I _really_ like the sound I got with these, these problems are pretty major. I thought I could make the update rate for distance parameter changes time-fixed, so that behavior doesn't depend on the host sample rate. That's not too hard, but it doesn't solve the performance problem, even if it means fewer full passes of resampling, those will still be big spikes each time they do happen.

Then I tried thinking about how to amortize the resampling. This is certainly possible until you start accumulating new distance changes while still playing through a portion of buffer recently resampled from a distance change. It might be possible to simulate that, like build up a map of rates over time or something, but it hurt my brain to solve that problem. If you have ideas as the doctor of mathematics between us, I'm keen to hear!

Anyway, those serious problems led to ad hoc varispeed mode. I find this one enjoyable and it does address my two goals, but the pitch changes aren't as wild and cumulative, not as fun, but I think it works pretty well.